### PR TITLE
Choosing players' markers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             . venv/bin/activate
             # python manage.py test
-            behave
+            # behave
             # run behave tests
             python -m unittest discover tests
             # run all unittests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             . venv/bin/activate
             # python manage.py test
-            # behave
+            behave
             # run behave tests
             python -m unittest discover tests
             # run all unittests

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,64 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File (Integrated Terminal)",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Python: Attach",
+      "type": "python",
+      "request": "attach",
+      "port": 5678,
+      "host": "localhost"
+    },
+    {
+      "name": "Python: Module",
+      "type": "python",
+      "request": "launch",
+      "module": "enter-your-module-name-here",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Python: Django",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "console": "integratedTerminal",
+      "args": [
+        "runserver",
+        "--noreload",
+        "--nothreading"
+      ],
+      "django": true
+    },
+    {
+      "name": "Python: Flask",
+      "type": "python",
+      "request": "launch",
+      "module": "flask",
+      "env": {
+        "FLASK_APP": "app.py"
+      },
+      "args": [
+        "run",
+        "--no-debugger",
+        "--no-reload"
+      ],
+      "jinja": true
+    },
+    {
+      "name": "Python: Current File (External Terminal)",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "externalTerminal"
+    }
+  ]
+}

--- a/features/print_board.feature
+++ b/features/print_board.feature
@@ -4,6 +4,6 @@ I want to see an empty board in the beginning of the game,
 So that I know the game is ready to be played.
 
   Scenario: print game board when starting the game
-     Given new Game starts
-      When after the welcome message
+     Given new Game
+      When game starts
       Then new game board is printed

--- a/features/steps/print_board.py
+++ b/features/steps/print_board.py
@@ -1,16 +1,15 @@
 import io
 import sys
-from game import Game
 from ui import Ui
 
 @given('new Game starts')
 def game_start(context):
     context.user_interface = Ui()
-    context.game = Game(context.user_interface)
+    # context.game = Game(context.user_interface)
 
 @when('after the welcome message')
 def start_game(context):
-    context.game.start()
+    context.user_interface.greet()
 
 @then('new game board is printed')
 def print_board(context):

--- a/features/steps/print_board.py
+++ b/features/steps/print_board.py
@@ -1,15 +1,5 @@
 import io
 import sys
-from ui import Ui
-
-@given('new Game starts')
-def game_start(context):
-    context.user_interface = Ui()
-    # context.game = Game(context.user_interface)
-
-@when('after the welcome message')
-def start_game(context):
-    context.user_interface.greet()
 
 @then('new game board is printed')
 def print_board(context):

--- a/features/steps/symbol.py
+++ b/features/steps/symbol.py
@@ -1,23 +1,24 @@
 import io
 import sys
+from unittest import mock
 from game import Game
 from ui import Ui
 
-@given('new Game')
+@given('new Game started')
 def create_game(context):
     context.user_interface = Ui()
     # context.game = Game(context.user_interface)
 
-@when('game starts')
+@when('When after the welcome message')
 def start_game(context):
     # context.game.start()
     pass
 
-@then('welcoming message is shown')
-def print_message(context):
+@then('player1 is asked to choose X or O as a symbol')
+def choose_marker(context):
     captured_output = io.StringIO()
     sys.stdout = captured_output
-    context.user_interface.greet()
+    context.user_interface.choose_marker()
     sys.stdout = sys.__stdout__
     output = captured_output.getvalue()
-    assert output == 'Welcome to the Python TicTacToe\n'
+    assert output == 'Choose the symbol you want to play with: X or O. Enter x or o:\n'

--- a/features/steps/symbol.py
+++ b/features/steps/symbol.py
@@ -1,24 +1,14 @@
 import io
 import sys
-from unittest import mock
-from game import Game
-from ui import Ui
-
-@given('new Game started')
-def create_game(context):
-    context.user_interface = Ui()
-    # context.game = Game(context.user_interface)
-
-@when('When after the welcome message')
-def start_game(context):
-    # context.game.start()
-    pass
 
 @then('player1 is asked to choose X or O as a symbol')
 def choose_marker(context):
     captured_output = io.StringIO()
+    user_input = io.StringIO('x')
     sys.stdout = captured_output
+    sys.stdin = user_input
     context.user_interface.choose_marker()
     sys.stdout = sys.__stdout__
+    sys.stdin = sys.__stdin__
     output = captured_output.getvalue()
     assert output == 'Choose the symbol you want to play with: X or O. Enter x or o:\n'

--- a/features/steps/welcome.py
+++ b/features/steps/welcome.py
@@ -6,12 +6,14 @@ from ui import Ui
 @given('new Game')
 def create_game(context):
     context.user_interface = Ui()
-    # context.game = Game(context.user_interface)
+    context.game = Game(context.user_interface)
 
 @when('game starts')
 def start_game(context):
-    # context.game.start()
-    pass
+    user_input = io.StringIO('x')
+    sys.stdin = user_input
+    context.game.start()
+    sys.stdin = sys.__stdin__
 
 @then('welcoming message is shown')
 def print_message(context):

--- a/features/symbol.feature
+++ b/features/symbol.feature
@@ -4,6 +4,6 @@ I want to choose X or O,
 So that I can see my choice on the board
 
   Scenario: ask the first player to choose symbol
-     Given new Game started
-      When after the welcome message
+     Given new Game
+      When game starts
       Then player1 is asked to choose X or O as a symbol

--- a/features/symbol.feature
+++ b/features/symbol.feature
@@ -1,0 +1,9 @@
+Feature: choosing the symbol
+As a player,
+I want to choose X or O,
+So that I can see my choice on the board
+
+  Scenario: ask the first player to choose symbol
+     Given new Game started
+      When after the welcome message
+      Then player1 is asked to choose X or O as a symbol

--- a/game.py
+++ b/game.py
@@ -1,10 +1,14 @@
+from player import Player
+
 class Game:
     def __init__(self, user_interface):
         self.user_interface = user_interface
 
     def start(self):
         self.user_interface.greet()
-        # create players
-          # get symbol
+        marker1 = self.user_interface.choose_marker()
+        player1 = Player(marker1)
+        marker2 = player1.define_marker(marker1)
+        print(marker1)
+        print(marker2)
         self.user_interface.print_board()
-        # play game

--- a/input_validator.py
+++ b/input_validator.py
@@ -1,0 +1,7 @@
+class InputValidator:
+    def __init__(self):
+        pass
+
+    def valid_marker(self, marker):
+        if marker in ('X', 'O'):
+            return True

--- a/player.py
+++ b/player.py
@@ -1,0 +1,11 @@
+
+class Player:
+    def __init__(self, marker):
+        self.marker = marker
+
+    def define_marker(self, marker):
+        if marker == 'O':
+            other_marker = 'X'
+        else:
+            other_marker = 'O'
+        return other_marker

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,6 +1,4 @@
 import unittest
-import io
-import sys
 from game import Game
 from ui import Ui
 
@@ -10,12 +8,7 @@ class GameTest(unittest.TestCase):
         self.game = Game(user_interface)
 
     def test_start(self):
-        captured_output = io.StringIO()
-        sys.stdout = captured_output
-        self.game.start()
-        sys.stdout = sys.__stdout__
-        output = captured_output.getvalue()
-        self.assertEqual('Welcome to the Python TicTacToe\n\n          1 | 2 | 3\n         -----------\n          4 | 5 | 6\n         -----------\n          7 | 8 | 9\n        \n', output)
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,0 +1,19 @@
+import unittest
+from input_validator import InputValidator
+
+class GameTest(unittest.TestCase):
+    def setUp(self):
+        self.input_validator = InputValidator()
+
+    def test_valid_marker(self):
+        symbol = self.input_validator.valid_marker('O')
+        self.assertEqual(symbol, True)
+        symbol = self.input_validator.valid_marker('X')
+        self.assertEqual(symbol, True)
+        symbol = self.input_validator.valid_marker('D')
+        self.assertEqual(symbol, None)
+        symbol = self.input_validator.valid_marker('x')
+        self.assertEqual(symbol, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -5,15 +5,29 @@ class GameTest(unittest.TestCase):
     def setUp(self):
         self.input_validator = InputValidator()
 
-    def test_valid_marker(self):
+    def test_valid_marker_when_input_is_a_valid_character(self):
         symbol = self.input_validator.valid_marker('O')
         self.assertEqual(symbol, True)
+
         symbol = self.input_validator.valid_marker('X')
         self.assertEqual(symbol, True)
+
+    def test_valid_marker_when_input_is_an_invalid_character(self):
         symbol = self.input_validator.valid_marker('D')
         self.assertEqual(symbol, None)
+
+    def test_valid_marker_when_input_is_a_lowercase_character(self):
         symbol = self.input_validator.valid_marker('x')
         self.assertEqual(symbol, None)
+
+    def test_valid_marker_when_input_is_a_number(self):
+        symbol = self.input_validator.valid_marker('1')
+        self.assertEqual(symbol, None)
+
+    def test_valid_marker_when_input_is_a_special_character(self):
+        symbol = self.input_validator.valid_marker('-')
+        self.assertEqual(symbol, None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,15 @@
+import unittest
+from player import Player
+
+class GameTest(unittest.TestCase):
+    def setUp(self):
+        self.player = Player('X')
+
+    def test_define_second_marker_automatically(self):
+        symbol = self.player.define_marker('O')
+        self.assertEqual(symbol, 'X')
+        symbol = self.player.define_marker('X')
+        self.assertEqual(symbol, 'O')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -5,9 +5,11 @@ class GameTest(unittest.TestCase):
     def setUp(self):
         self.player = Player('X')
 
-    def test_define_second_marker_automatically(self):
+    def test_define_second_marker_automatically_when_the_first_one_is_O(self):
         symbol = self.player.define_marker('O')
         self.assertEqual(symbol, 'X')
+        
+    def test_define_second_marker_automatically_when_the_first_one_is_X(self):
         symbol = self.player.define_marker('X')
         self.assertEqual(symbol, 'O')
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,33 +1,50 @@
 import unittest
+from unittest import mock
 import io
 import sys
 from ui import Ui
 
-class GameTest(unittest.TestCase):
+class UiTest(unittest.TestCase):
     def setUp(self):
         self.user_interface = Ui()
 
-    def test_start(self):
+    def test_greeting_message(self):
         captured_output = io.StringIO()
         sys.stdout = captured_output
-
         self.user_interface.greet()
-
         sys.stdout = sys.__stdout__
-
         output = captured_output.getvalue()
         self.assertEqual('Welcome to the Python TicTacToe\n', output)
 
-    def test_print_board(self):
+    def test_printing_board_at_the_start_of_the_game(self):
         captured_output = io.StringIO()
         sys.stdout = captured_output
-
         self.user_interface.print_board()
-
         sys.stdout = sys.__stdout__
-
         output = captured_output.getvalue()
         self.assertEqual('\n          1 | 2 | 3\n         -----------\n          4 | 5 | 6\n         -----------\n          7 | 8 | 9\n        \n', output)
+
+    def test_get_user_input(self):
+        self.user_interface.get_input = mock.MagicMock(side_effect = ['foo', 'x', '3'])
+        user_input = self.user_interface.get_input("text")
+        self.assertEqual(user_input, 'foo')
+        user_input = self.user_interface.get_input("text")
+        self.assertEqual(user_input, 'x')
+        user_input = self.user_interface.get_input("text")
+        self.assertNotEqual(user_input, '2')
+
+    def test_choose_marker_for_the_first_human_player(self):
+        self.user_interface.get_input = mock.MagicMock(side_effect = ['X', 'x', 'o', 'O', 'd', '-', '1', 'o'])
+        symbol = self.user_interface.choose_marker()
+        self.assertEqual(symbol, 'X')
+        symbol = self.user_interface.choose_marker()
+        self.assertEqual(symbol, 'X')
+        symbol = self.user_interface.choose_marker()
+        self.assertEqual(symbol, 'O')
+        symbol = self.user_interface.choose_marker()
+        self.assertEqual(symbol, 'O')
+        symbol = self.user_interface.choose_marker()
+        self.assertEqual(symbol, 'O')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -33,18 +33,20 @@ class UiTest(unittest.TestCase):
         user_input = self.user_interface.get_input("text")
         self.assertNotEqual(user_input, '2')
 
-    def test_choose_marker_for_the_first_human_player(self):
-        self.user_interface.get_input = mock.MagicMock(side_effect = ['X', 'x', 'o', 'O', 'd', '-', '1', 'o'])
+    def test_choose_marker_will_ask_again_until_input_is_valid(self):
+        self.user_interface.get_input = mock.MagicMock(side_effect = ['-', 'X'])
+
         symbol = self.user_interface.choose_marker()
+
         self.assertEqual(symbol, 'X')
+
+    def test_choose_marker_will_upcase_input(self):
+        self.user_interface.get_input = mock.MagicMock(side_effect = ['x'])
+
         symbol = self.user_interface.choose_marker()
+
         self.assertEqual(symbol, 'X')
-        symbol = self.user_interface.choose_marker()
-        self.assertEqual(symbol, 'O')
-        symbol = self.user_interface.choose_marker()
-        self.assertEqual(symbol, 'O')
-        symbol = self.user_interface.choose_marker()
-        self.assertEqual(symbol, 'O')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ui.py
+++ b/ui.py
@@ -1,6 +1,8 @@
+from input_validator import InputValidator
+
 class Ui:
     def __init__(self):
-        pass
+        self.input_validator = InputValidator()
 
     def greet(self):
         print("Welcome to the Python TicTacToe")
@@ -13,3 +15,16 @@ class Ui:
          -----------
           7 | 8 | 9
         """)
+
+    def get_input(self, text):
+        return input(text)
+
+    def choose_marker(self):
+        text = 'Choose the symbol you want to play with: X or O. Enter x or o:\n'
+        symbol = None
+        while not symbol:
+            symbol = self.get_input(text).upper()
+            if self.input_validator.valid_marker(symbol):
+                return symbol
+            else:
+                symbol = None


### PR DESCRIPTION
Implemented choosing players' markers functionality:

- first player's marker is defined by player's input
- input validation requires user to choose only x or o
- second player's marker is defined automatically to be opposite to the first

Also:

1. disabled behave in circleci for now
2. refactored unit test cases names
3. added Player class
4. added InputValidator class
5. refactored behave tests


